### PR TITLE
Improvements to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS = -O3 -I./utils/inc -D_FILE_OFFSET_BITS=64 -DCONSOLE_SUPPORTS_COLOR -Wall -std=c++11 -Wfatal-errors
+CXXFLAGS += -O3 -I./utils/inc -D_FILE_OFFSET_BITS=64 -DCONSOLE_SUPPORTS_COLOR -Wall -std=c++11 -Wfatal-errors
 CXX = clang++
 LD = $(CXX)
 LIBS=-lpthread
@@ -22,4 +22,4 @@ log.o: utils/src/log.cpp
 	$(CXX) -c $(CXXFLAGS) $^ -o $@
 
 clean:
-	rm *.o
+	rm -f *.o


### PR DESCRIPTION
Respect external CXXFLAGS (useful for integrating with Gentoo ebuilds) and prevent an error when calling clean when there are no object files